### PR TITLE
Remove authorization header on redirect to different host

### DIFF
--- a/test/server.js
+++ b/test/server.js
@@ -252,6 +252,31 @@ module.exports = class TestServer {
 			res.end();
 		}
 
+		if (p === '/redirect/host/different') {
+			res.statusCode = 301;
+			res.setHeader('Location', 'http://127.0.0.1:30001/inspect');
+			res.end();
+		}
+
+		if (p === '/redirect/host/same') {
+			res.statusCode = 301;
+			res.setHeader('Location', 'localhost:30001/inspect');
+			res.end();
+		}
+
+		if (p === '/redirect/host/relativeuri') {
+			res.statusCode = 301;
+			res.setHeader('Location', '/inspect')
+			res.end()
+		}
+
+		if (p === '/redirect/host/protocolrelative') {
+			res.statusCode = 301;
+			res.setHeader('Location', '//localhost:30001/inspect')
+			res.end()
+		}
+
+
 		if (p === '/error/400') {
 			res.statusCode = 400;
 			res.setHeader('Content-Type', 'text/plain');

--- a/test/test.js
+++ b/test/test.js
@@ -41,6 +41,7 @@ const supportToString = ({
 
 const local = new TestServer();
 const base = `http://${local.hostname}:${local.port}/`;
+const redirectBase = `http://127.0.0.1:${local.port}/`;
 let url, opts;
 
 before(done => {
@@ -251,7 +252,63 @@ describe('node-fetch', () => {
 		});
 	});
 
-	it('should follow POST request redirect code 301 with GET', function() {
+	it('should remove authorization header on redirect if hostname changed', function () {
+		url = `${base}redirect/host/different`
+		opts = {
+			headers: new Headers({ 'authorization': 'abc' })
+		};
+		return fetch(url, opts).then(res => {
+			expect(res.url).to.equal(`${redirectBase}inspect`);
+			return res.json()
+			.then(res => {
+				expect(res.headers['authorization']).to.be.undefined;
+			});
+		});
+	});
+
+	it('should preserve authorization header on redirect if hostname did not change', function () {
+		url = `${base}redirect/host/same`
+		opts = {
+			headers: new Headers({ 'authorization': 'abc' })
+		};
+		return fetch(url, opts).then(res => {
+			expect(res.url).to.equal(`${base}inspect`);
+			return res.json()
+			.then(res => {
+				expect(res.headers['authorization']).to.equal('abc');
+			});
+		});
+	});
+	
+	it('should preserve authorization header on redirect if url is relative', function () {
+		url = `${base}redirect/host/relativeuri`
+		opts = {
+			headers: new Headers({ 'authorization': 'abc' })
+		};
+		return fetch(url, opts).then(res => {
+			expect(res.url).to.equal(`${base}inspect`);
+			return res.json()
+			.then(res => {
+				expect(res.headers['authorization']).to.equal('abc');
+			});
+		});
+	});
+	
+	it('should preserve authorization header on redirect if url is protocol relative', function () {
+		url = `${base}redirect/host/protocolrelative`
+		opts = {
+			headers: new Headers({ 'authorization': 'abc' })
+		};
+		return fetch(url, opts).then(res => {
+			expect(res.url).to.equal(`${base}inspect`);
+			return res.json()
+			.then(res => {
+				expect(res.headers['authorization']).to.equal('abc');
+			});
+		});
+	});
+
+	it('should follow POST request redirect code 301 with GET', function () {
 		url = `${base}redirect/301`;
 		opts = {
 			method: 'POST'


### PR DESCRIPTION
Matches the behavior of request:
https://github.com/request/request/blob/b12a6245/lib/redirect.js#L134-L138

Fixes #1 

A few cases are missing from the tests but I wasn't sure if I should create a new server just for that and I dunno if I should test all redirect status codes for this case.

I wasn't sure if this had to be handled in that piece of code you pointed to, cause that only seems to cover POST requests and from the `request` code it seems that they do it for all methods but HEAD
